### PR TITLE
Remove missing fontWeights import

### DIFF
--- a/packages/frontity-starter-theme/src/theme-ui/index.js
+++ b/packages/frontity-starter-theme/src/theme-ui/index.js
@@ -1,17 +1,10 @@
 import { colors, buttons, text, card, header, footer } from "./components";
-import {
-  fonts,
-  fontSizes,
-  fontWeights,
-  lineHeights,
-  base
-} from "./components/typo";
+import { fonts, fontSizes, lineHeights, base } from "./components/typo";
 
 export default {
   colors,
   fonts,
   fontSizes,
-  fontWeights,
   lineHeights,
   text,
   buttons,


### PR DESCRIPTION
There was an import of an undefined variable that was causing a webpack warning.