### PR TITLE
Remove getSnapshot warning in React

### DIFF
--- a/packages/frontity-starter-theme/src/components/post/postEntryMedia.js
+++ b/packages/frontity-starter-theme/src/components/post/postEntryMedia.js
@@ -4,7 +4,15 @@ import { connect } from "frontity";
 import { getMediaAttributes } from "../../helpers";
 import Image from "@frontity/components/image";
 
-function PostEntryMedia({ state, actions, libraries, id, ratio, ...props }) {
+function PostEntryMedia({
+  state,
+  actions,
+  libraries,
+  id,
+  ratio,
+  getSnapshot,
+  ...props
+}) {
   const imgProps = getMediaAttributes(state, id);
   // is empty if the id doesn't exist in state.source anymore
   const noImgProps = Object.keys(imgProps).length === 0;


### PR DESCRIPTION
This warning was actually our fault. I have done a PR to Frontity to solve it: https://github.com/frontity/frontity/pull/360