### PR TITLE
removing margin none property

### DIFF
--- a/packages/frontity-starter-theme/src/theme-ui/components/header.js
+++ b/packages/frontity-starter-theme/src/theme-ui/components/header.js
@@ -2,7 +2,7 @@ export const header = {
   bg: 'headerBg',
   color: 'headerColor',
   fontWeight: 'bold',
-  margin: 'none',
+  margin: 0,
   boxShadow: 'small',
   '.container': {
     display: ['flex'],


### PR DESCRIPTION
Hi @alexadark 

Just creating a small fix to property the margin with a value none at the header:

<img width="800" alt="Screen Shot 2020-10-12 at 08 47 49" src="https://user-images.githubusercontent.com/330792/95721263-3d555000-0c6a-11eb-84be-0e5981fa1829.png">
  